### PR TITLE
feat: replace lingering default bundle prefixes

### DIFF
--- a/src/config/bundleIdentifiers.js
+++ b/src/config/bundleIdentifiers.js
@@ -6,6 +6,10 @@ export function bundleIdentifiers(currentAppName, newName, projectName, currentB
   const nS_NewName = newName.replace(/\s/g, '');
   const lC_Ns_CurrentBundleID = currentBundleID.toLowerCase();
   const lC_Ns_NewBundleID = newBundleID.toLowerCase();
+  const lC_Ns_NewBundleIDPrefix = lC_Ns_NewBundleID
+    .split('.')
+    .slice(0, -1)
+    .join('.');
 
   return [
     {
@@ -37,6 +41,18 @@ export function bundleIdentifiers(currentAppName, newName, projectName, currentB
       regex: currentBundleID,
       replacement: newBundleID,
       paths: ['ios/' + nS_NewName + '.xcodeproj/project.pbxproj'],
+    },
+    {
+      // Change default Bundle ID prefix in iOS (project.pbxproj)
+      regex: `com.facebook.REACT.${nS_CurrentAppName}`,
+      replacement: newBundleID,
+      paths: ['ios/' + nS_NewName + '.xcodeproj/project.pbxproj', `ios/${nS_NewName}/Info.plist`],
+    },
+    {
+      // Change default tvOS related Bundle ID prefix in iOS (project.pbxproj)
+      regex: /org\.reactjs\.native\.example\.\$\(PRODUCT_NAME:rfc1034identifier\)/g,
+      replacement: `${lC_Ns_NewBundleIDPrefix}.$(PRODUCT_NAME:rfc1034identifier)`,
+      paths: ['ios/' + nS_NewName + '.xcodeproj/project.pbxproj', `ios/${nS_NewName}-tvOSTests/Info.plist`],
     },
   ];
 }


### PR DESCRIPTION
Replaces `com.facebook.REACT.` and `org.reactjs.native.example.`, replacing them with new bundle ID (prefix)